### PR TITLE
Appsrn 405 preparar worklogs para ser enviados al finalizar un turno de tracking

### DIFF
--- a/__mocks__/index.js
+++ b/__mocks__/index.js
@@ -127,3 +127,48 @@ export const mockFormattedActivities = [
 		duration: 1800, // 30 minutos en segundos
 	},
 ];
+
+// Mock data para offline worklogs
+export const mockPendingWorkLogs = [
+	{
+		referenceId: 'ref-1',
+		startDate: '2024-01-15T10:00:00.000Z',
+		endDate: '2024-01-15T12:00:00.000Z',
+	},
+	{
+		referenceId: 'ref-2',
+		startDate: '2024-01-15T11:00:00.000Z',
+		endDate: '2024-01-15T11:30:00.000Z',
+	},
+];
+
+// Mock para formatted offline worklogs
+export const mockFormattedOfflineWorkLogs = [
+	{
+		workLogTypeRefId: 'ref-1',
+		startDate: '2024-01-15T10:00:00.000Z',
+		endDate: '2024-01-15T12:00:00.000Z',
+	},
+	{
+		workLogTypeRefId: 'ref-2',
+		startDate: '2024-01-15T11:00:00.000Z',
+		endDate: '2024-01-15T11:30:00.000Z',
+	},
+];
+
+// Mock para OfflineData
+export const mockOfflineData = {
+	hasData: false,
+	get: jest.fn(() => []),
+	save: jest.fn(),
+	delete: jest.fn(),
+	deleteAll: jest.fn(),
+};
+
+// Mock para respuestas de postWorklog con batch de pendientes
+export const mockPostWorklogBatchResponse = {
+	result: {
+		itemsCreated: [{id: 'worklog-batch-1'}, {id: 'worklog-batch-2'}],
+		itemsUpdated: [],
+	},
+};

--- a/lib/Formatter.js
+++ b/lib/Formatter.js
@@ -130,6 +130,40 @@ class Formatter {
 
 		return workLogMapper[workLog] || workLogMapper.default;
 	}
+
+	/**
+	 * Formats offline work logs for sending to the server.
+	 *
+	 * @param {Array<Object>} offlineWorkLog - Array of offline work log objects
+	 * @returns {Array<{
+	 *   workLogTypeRefId: string,
+	 *   startDate: string,
+	 *   endDate: string
+	 * }>} Array of formatted work log objects for sending to the server.
+	 *
+	 * @property {string} workLogTypeRefId - Reference identifier for the work log type
+	 * @property {string | null} startDate - ISO timestamp when the work log started
+	 * @property {string | null} endDate - ISO timestamp when the work log ended
+	 */
+	static formatOfflineWorkLog(offlineWorkLog = []) {
+		if (!isArray(offlineWorkLog)) {
+			offlineWorkLog = [offlineWorkLog];
+		}
+
+		return offlineWorkLog
+			.map((workLog) => {
+				const {referenceId, startDate, endDate} = workLog || {};
+
+				if (!referenceId) return null;
+
+				return {
+					workLogTypeRefId: referenceId,
+					...(startDate && {startDate}),
+					...(endDate && {endDate}),
+				};
+			})
+			.filter(Boolean);
+	}
 }
 
 export default Formatter;

--- a/lib/OfflineData.js
+++ b/lib/OfflineData.js
@@ -1,0 +1,91 @@
+import {OFFLINE_DATA} from './constant';
+import Storage from './db/StorageService';
+import {isArray, isEmptyArray} from './utils/helpers';
+import {setObject, getObject} from './utils/storage';
+
+class OfflineData {
+	get hasData() {
+		const offlineData = getObject(OFFLINE_DATA, {});
+		return Object.keys(offlineData).length > 0;
+	}
+
+	/**
+	 * Saves data to the offline data storage.
+	 *
+	 * @param {string} storageId - The ID of the storage to save the data to.
+	 * @param {Object} data - The data to save.
+	 */
+
+	save(storageId, data) {
+		try {
+			const offlineData = getObject(OFFLINE_DATA, {});
+			offlineData[storageId] = {...offlineData[storageId], ...data};
+			setObject(OFFLINE_DATA, offlineData);
+		} catch (error) {
+			throw new Error(error);
+		}
+	}
+
+	/**
+	 * Gets data from the offline data storage.
+	 *
+	 * @param {string | Array<string> | null} storageId - The ID of the storage to get the data from.
+	 * @returns {Array<Object>} The data from the storage.
+	 */
+
+	get(storageId = null) {
+		try {
+			const offlineData = getObject(OFFLINE_DATA, {});
+
+			if (!isArray(storageId)) {
+				storageId = [storageId].filter(Boolean);
+			}
+
+			if (isEmptyArray(storageId)) return Object.values(offlineData);
+
+			return storageId.map((id) => offlineData[id]);
+		} catch (error) {
+			throw new Error(error);
+		}
+	}
+
+	/**
+	 * Deletes data from the offline data storage.
+	 *
+	 * @param {string | Array<string>} storageId - The ID of the storage to delete the data from.
+	 */
+
+	delete(storageId) {
+		try {
+			const offlineData = getObject(OFFLINE_DATA, {});
+
+			if (!isArray(storageId)) {
+				storageId = [storageId].filter(Boolean);
+			}
+
+			if (isEmptyArray(storageId)) return;
+
+			storageId.forEach((id) => {
+				delete offlineData[id];
+			});
+
+			setObject(OFFLINE_DATA, offlineData);
+		} catch (error) {
+			throw new Error(error);
+		}
+	}
+
+	/**
+	 * Deletes all data from the offline data storage.
+	 */
+
+	deleteAll() {
+		try {
+			Storage.delete(OFFLINE_DATA);
+		} catch (error) {
+			throw new Error(error);
+		}
+	}
+}
+
+export default new OfflineData();

--- a/lib/Shift.js
+++ b/lib/Shift.js
@@ -3,8 +3,8 @@ import StaffService from './StaffApiServices';
 import Storage from './db/StorageService';
 import Crashlytics from './utils/crashlytics';
 import ShiftWorklogs from './ShiftWorklogs';
-import {generateRandomId, isEmptyObject, isObject} from './utils/helpers';
-import {getShiftData} from './utils/storage';
+import {generateRandomId, isEmptyArray, isEmptyObject, isObject} from './utils/helpers';
+import {getObject, getShiftData, setObject} from './utils/storage';
 import {
 	SHIFT_ID,
 	SHIFT_STATUS,
@@ -12,10 +12,11 @@ import {
 	CURRENT_WORKLOG_DATA,
 	CURRENT_WORKLOG_ID,
 	EXCLUDED_WORKLOG_TYPES,
+	ONE_HOUR_EXTENSION,
 } from './constant';
 import TrackerRecords from './TrackerRecords';
 import Formatter from './Formatter';
-
+import OfflineData from './OfflineData';
 /**
  * Class to manage work shifts
  * @class Shift
@@ -77,6 +78,11 @@ class Shift {
 	async finish(params = {}) {
 		try {
 			Crashlytics.log('user close shift');
+
+			if (OfflineData.hasData) {
+				await this.sendPendingWorkLogs();
+			}
+
 			const {date} = params;
 			const {result: shift} = await StaffService.closeShift();
 			const {id: shiftId = ''} = shift || {};
@@ -120,14 +126,14 @@ class Shift {
 			const {referenceId, name, type, suggestedTime = 0} = workLog;
 			const shiftId = Storage.getString(SHIFT_ID);
 			const startTime = new Date();
-			const workLogId = generateRandomId();
+			const randomId = generateRandomId();
 
-			const formattedWorkLogId = Formatter.formatWorkLogId(referenceId, workLogId);
+			const workLogId = Formatter.formatWorkLogId(referenceId, randomId);
 
-			await ShiftWorklogs.open({
-				referenceId,
-				startDate: startTime.toISOString(),
-			});
+			// await ShiftWorklogs.open({
+			// 	referenceId,
+			// 	startDate: startTime.toISOString(),
+			// });
 
 			const dataForTimeTracker = {
 				type,
@@ -136,8 +142,13 @@ class Shift {
 				referenceId,
 			};
 
+			OfflineData.save(workLogId, {
+				referenceId,
+				startDate: startTime.toISOString(),
+			});
+
 			await this._startTracking({
-				id: formattedWorkLogId,
+				id: workLogId,
 				date: startTime.toISOString(),
 				payload: dataForTimeTracker,
 			});
@@ -156,10 +167,10 @@ class Shift {
 				Storage.set(SHIFT_STATUS, 'paused');
 			}
 
-			Storage.set(CURRENT_WORKLOG_ID, formattedWorkLogId);
+			Storage.set(CURRENT_WORKLOG_ID, workLogId);
 			Storage.set(CURRENT_WORKLOG_DATA, JSON.stringify(dataForStorage));
 
-			return formattedWorkLogId;
+			return workLogId;
 		} catch (error) {
 			Crashlytics.recordError(error, 'Error opening shift worklog');
 			return Promise.reject(error);
@@ -187,10 +198,10 @@ class Shift {
 			const endTime = new Date().toISOString();
 			const workLogId = Storage.getString(CURRENT_WORKLOG_ID);
 
-			await ShiftWorklogs.finish({
-				referenceId,
-				endDate: endTime,
-			});
+			// await ShiftWorklogs.finish({
+			// 	referenceId,
+			// 	endDate: endTime,
+			// });
 
 			const dataForTimeTracker = {
 				type,
@@ -198,6 +209,11 @@ class Shift {
 				shiftId,
 				referenceId,
 			};
+
+			OfflineData.save(workLogId, {
+				referenceId,
+				endDate: endTime,
+			});
 
 			await this._finishTracking({
 				id: workLogId,
@@ -209,12 +225,27 @@ class Shift {
 				Storage.set(SHIFT_STATUS, 'opened');
 			}
 
-			Storage.delete(CURRENT_WORKLOG_ID);
-			Storage.delete(CURRENT_WORKLOG_DATA);
+			this._deleteCurrentWorkLogData();
 
 			return workLogId;
 		} catch (error) {
 			Crashlytics.recordError(error, 'Error closing shift worklog');
+			return Promise.reject(error);
+		}
+	}
+
+	async sendPendingWorkLogs() {
+		try {
+			const storageData = OfflineData.get();
+			const formatedWorkLogs = Formatter.formatOfflineWorkLog(storageData);
+
+			if (isEmptyArray(formatedWorkLogs)) return null;
+
+			await ShiftWorklogs.postPendingBatch(formatedWorkLogs);
+			OfflineData.deleteAll();
+			return null;
+		} catch (error) {
+			Crashlytics.recordError(error, 'Error posting pending work logs');
 			return Promise.reject(error);
 		}
 	}
@@ -249,6 +280,45 @@ class Shift {
 		}
 	}
 
+	/**
+	 * Re open current shift in the staff MS and extend storage shift closing date.
+	 * @throws {Error} error
+	 * @returns {Promise<null>} null
+	 */
+
+	async reOpen() {
+		try {
+			Crashlytics.log('user re open shift');
+			const shiftIsExpired = this.isDateMaxToCloseExceeded();
+
+			if (shiftIsExpired) {
+				throw new Error('The deadline for ending the shift has been exceeded');
+			}
+			await StaffService.openShift();
+			this._extendShiftClosingDate();
+
+			return null;
+		} catch (error) {
+			Crashlytics.recordError(error, 'Error re opening shift');
+			return Promise.reject(error);
+		}
+	}
+
+	isDateToCloseExceeded() {
+		const shiftData = getObject(SHIFT_DATA);
+		const {dateToClose} = shiftData;
+		const currentDate = new Date();
+
+		return new Date(dateToClose).getTime() < currentDate.getTime();
+	}
+
+	isDateMaxToCloseExceeded() {
+		const shiftData = getObject(SHIFT_DATA);
+		const {dateMaxToClose} = shiftData;
+		const currentDate = new Date();
+
+		return new Date(dateMaxToClose).getTime() < currentDate.getTime();
+	}
 	/**
 	 * Gets a shift report based on the shift ID and its registered events.
 	 *
@@ -357,16 +427,25 @@ class Shift {
 	async deleteShiftRegisters() {
 		try {
 			Crashlytics.log('user delete shift registers');
-			Storage.delete(SHIFT_ID);
-			Storage.delete(SHIFT_STATUS);
-			Storage.delete(SHIFT_DATA);
-			Storage.delete(CURRENT_WORKLOG_ID);
-			Storage.delete(CURRENT_WORKLOG_DATA);
+			this._deleteShiftData();
+			this._deleteCurrentWorkLogData();
+			OfflineData.deleteAll();
 			return await TimeTracker.deleteAllEvents();
 		} catch (error) {
 			Crashlytics.recordError(error, 'Error deleting registers from shift tracking database');
 			return Promise.reject(error);
 		}
+	}
+
+	_deleteShiftData() {
+		Storage.delete(SHIFT_ID);
+		Storage.delete(SHIFT_STATUS);
+		Storage.delete(SHIFT_DATA);
+	}
+
+	_deleteCurrentWorkLogData() {
+		Storage.delete(CURRENT_WORKLOG_ID);
+		Storage.delete(CURRENT_WORKLOG_DATA);
 	}
 
 	/**
@@ -405,6 +484,23 @@ class Shift {
 			type: 'finish',
 			payload,
 		}).catch(() => null);
+	}
+
+	/**
+	 * @private
+	 * Extend the shift closing date.
+	 * @throws {Error} error
+	 * @returns {Promise<null>} null
+	 */
+
+	_extendShiftClosingDate() {
+		const shiftData = getObject(SHIFT_DATA);
+		const {dateToClose} = shiftData;
+		const updatedClosingDate = new Date(dateToClose).getTime() + ONE_HOUR_EXTENSION;
+
+		shiftData.dateToClose = new Date(updatedClosingDate).toISOString();
+
+		setObject(SHIFT_DATA, shiftData);
 	}
 }
 export default new Shift();

--- a/lib/ShiftWorklogs.js
+++ b/lib/ShiftWorklogs.js
@@ -1,5 +1,6 @@
 import StaffApiServices from './StaffApiServices';
 import TrackerRecords from './TrackerRecords';
+import {isArray, isEmptyArray} from './utils/helpers';
 
 class ShiftWorklogs {
 	async open(params) {
@@ -56,6 +57,17 @@ class ShiftWorklogs {
 			shiftWorkLogs.sort((a, b) => new Date(a?.time) - new Date(b?.time));
 
 			return shiftWorkLogs;
+		} catch (error) {
+			return Promise.reject(error);
+		}
+	}
+
+	async postPendingBatch(pendingWorkLogs = []) {
+		try {
+			if (!isArray(pendingWorkLogs) || isEmptyArray(pendingWorkLogs)) return null;
+
+			await StaffApiServices.postWorklog(pendingWorkLogs);
+			return null;
 		} catch (error) {
 			return Promise.reject(error);
 		}

--- a/lib/constant/index.js
+++ b/lib/constant/index.js
@@ -4,9 +4,9 @@ export const SHIFT_STATUS = 'shift.status';
 export const SHIFT_DATA = 'shift.data';
 export const WORKLOG_TYPES_DATA = 'worklogTypes.data';
 export const CURRENT_WORKLOG_ID = 'worklog.id';
-export const CURRENT_WORKLOG_START_TIME = 'worklog.startTime';
 export const CURRENT_WORKLOG_DATA = 'worklog.data';
 export const STAFF_AUTH = 'staff.authorization';
+export const OFFLINE_DATA = 'offline.data';
 
 // EXPIRATION TIMES
 export const WORKLOG_TYPES_EXPIRATION_TIME = 4 * 60 * 60 * 1000; // 4 hours
@@ -28,3 +28,6 @@ export const INTERNAL_WORKLOGS = {
 		name: 'Default delivery work',
 	},
 };
+
+// SHIFT CLOSE EXTENSION
+export const ONE_HOUR_EXTENSION = 60 * 60 * 1000; // 1 hour

--- a/lib/utils/storage/index.js
+++ b/lib/utils/storage/index.js
@@ -1,3 +1,19 @@
+import Storage from '../../db/StorageService';
+
 export {default as getWorkLogTypesData} from './getWorkLogTypesData';
 export {default as getShiftData} from './getShiftData';
 export {default as getStaffAuthorizationData} from './getStaffAuthorizationData';
+
+export const setObject = (key, value) => {
+	const jsonValue = JSON.stringify(value);
+	Storage.set(key, jsonValue);
+};
+
+export const getObject = (key, defaultValue = {}) => {
+	try {
+		const jsonValue = Storage.getString(key);
+		return JSON.parse(jsonValue);
+	} catch (error) {
+		return defaultValue;
+	}
+};

--- a/setupTest/jest.setup.js
+++ b/setupTest/jest.setup.js
@@ -1,4 +1,10 @@
-import {mockRequest, mockTimeTracker, mockCrashlytics, mockMMKV} from '../__mocks__';
+import {
+	mockRequest,
+	mockTimeTracker,
+	mockCrashlytics,
+	mockMMKV,
+	mockOfflineData,
+} from '../__mocks__';
 
 jest.mock('@janiscommerce/app-request', () => ({
 	__esModule: true,
@@ -84,6 +90,7 @@ jest.mock('../lib/ShiftWorklogs', () => ({
 		open: jest.fn(),
 		finish: jest.fn(),
 		getShiftTrackedWorkLogs: jest.fn(),
+		postPendingBatch: jest.fn(),
 	},
 }));
 
@@ -94,6 +101,7 @@ jest.mock('../lib/Formatter', () => ({
 		formatShiftActivities: jest.fn(),
 		formatWorkLogTypes: jest.fn(),
 		formatWorkLogId: jest.fn(),
+		formatOfflineWorkLog: jest.fn(),
 	},
 }));
 
@@ -153,11 +161,6 @@ jest.mock('../lib/utils/helpers', () => {
 	};
 });
 
-jest.mock('../lib/utils/storage', () => ({
-	__esModule: true,
-	getShiftData: jest.fn(),
-}));
-
 // Mock TrackerRecords
 jest.mock('../lib/TrackerRecords', () => ({
 	__esModule: true,
@@ -165,5 +168,22 @@ jest.mock('../lib/TrackerRecords', () => ({
 		getWorkLogsFromTimeTracker: jest.fn(),
 		getStartDateById: jest.fn(),
 		getEndDateById: jest.fn(),
+		getClientShiftActivities: jest.fn(),
 	},
+}));
+
+// Mock OfflineData
+jest.mock('../lib/OfflineData', () => ({
+	__esModule: true,
+	default: mockOfflineData,
+}));
+
+// Mock utils/storage
+jest.mock('../lib/utils/storage', () => ({
+	__esModule: true,
+	getShiftData: jest.fn(),
+	getWorkLogTypesData: jest.fn(),
+	getStaffAuthorizationData: jest.fn(),
+	setObject: jest.fn(),
+	getObject: jest.fn(),
 }));


### PR DESCRIPTION
## LINK DE TICKET
https://janiscommerce.atlassian.net/browse/APPSRN-405
## DESCRIPCIÓN DEL REQUERIMIENTO:
Se requiere que, al finalizar un turno, se valide si quedaron tiempos de actividades pendientes de enviar a janis. 
Para esto, tenemos que almacenar (en el storage de mmkv) una referencia al id del workLog para que, antes de finalizar el turno, se compruebe qué actividades no fueron reportadas a janis.

Esta comprobación debe ejecutarse antes de la request para cerrar el turno. 

ℹ️  Tener en cuenta que:
- Si la request para finalizar workLogs falla, no se debe continuar con la ejecución de finalización de turno.
- Si se completa la request, automáticamente deben eliminarse todos los ids de worklogs pendientes del storage.
- Antes de tratar de finalizar la actividad se debe comprobar que el turno siga abierto, y en caso contrario, volver a abrirlo para poder enviar las actividades pendientes.

💡 Para manejar la información de actividades dentro del storage vamos a necesitar agregar una nueva clase de nombre offlineData, que se encargue de:
- Guardar y actualizar la información de las actividades pendientes de ser enviadas. 
- Obtener las actividades desde el storage para preparar la información que será enviada a janis. 
- Poder eliminarla.

⚠️ Momentáneamente, se debe remover la request a janis de los métodos openWorkLog y finishWorkLog; esto será actualizado en una versión posterior, pero de esta manera nos aseguramos de enviar toda la información DE UNA SOLA VEZ.

📎   Se debe agregar un nuevo método para corroborar si, antes de enviar una request, se necesita abrir nuevamente el turno. Esta request debe ejecutarse antes de todo lo mencionado, ya que, en caso de no tener el turno abierto, las request de finalización de:
- worklogs => fallarán.
- turnos => serán exitosas, pero no actualizarán la hora de finalización.

## DESCRIPCIÓN DE LA SOLUCIÓN:
Se agregó la nueva clase OfflineData, que se encarga de manejar qué información se almacena en el storage y queda pendiente de enviar a janis. También permite obtenerla y/o eliminarla por id o ids, o también completamente.

Esta clase se usa dentro de Shift para:
- Guardar la información de los workLogs que deben ser enviados al finalizar el turno.
- Obtener esa informaciión
- Eliminarla una vez que se haya enviado.

Dentro de Shift se hicieron los siguientes cambios:

#### Ajustes:
- Se deja comentada la request a janis dentro de los métodos openWorkLog y finishWorkLog. En su lugar, ahora se guarda la referencia del worklog creado/finalizado en el storage de offlineData y es enviado al finalizar.
- Antes de finalizar el turno, se chequea si quedaron workLogs pendientes de enviar a janis para hacerlo en caso de ser necesario.

#### Nuevos métodos:
- `sendPendingWorkLog`: se encarga de chequear el storage de offlineData y hacer la request a janis con la información de cada workLog pendiente.
- `reOpen`: se encarga de reabrir el turno en janis. Se diferencia del método open porque no interactua con la base de datos de tracking ni el storage, sólo valida la hora máxima de cierre del turno en curso y hace la request si aún no se ha excedido.
- `isDateToCloseExceeded`: devuelve un booleano que indica si se superó (o no) la hora de finalización del turno en curso.
- `isDateMaxToCloseExceeded`: devuelve un booleano que indica si se superó la hora máxima de validez del turno.

También se agregaron funciones métodos dentro de shiftWorkLogs y Formatter para manejar la información de las actividades pendientes de ser enviadas

## ¿CÓMO PROBARLO?
## DATOS EXTRA A TENER EN CUENTA:
