### PR TITLE
added getters to check pending data and storage authorization

### DIFF
--- a/__test__/Shift.test.js
+++ b/__test__/Shift.test.js
@@ -23,7 +23,7 @@ import {
 import Storage from '../lib/db/StorageService';
 import ShiftWorklogs from '../lib/ShiftWorklogs';
 import TrackerRecords from '../lib/TrackerRecords';
-import {getShiftData, getObject} from '../lib/utils/storage';
+import {getShiftData, getObject, getStaffAuthorizationData} from '../lib/utils/storage';
 import Formatter from '../lib/Formatter';
 import Shift from '../lib/Shift';
 import OfflineData from '../lib/OfflineData';
@@ -60,6 +60,15 @@ describe('Shift', () => {
 	});
 
 	describe('open', () => {
+		it('should throw error when user does not have staff authorization', async () => {
+			// Mock getStaffAuthorizationData to return false for this test
+			getStaffAuthorizationData.mockReturnValueOnce({hasStaffAuthorization: false});
+
+			await expect(Shift.open()).rejects.toThrow('Staff MS authorization is required');
+			expect(mockCrashlytics.log).toHaveBeenCalled();
+			expect(mockCrashlytics.recordError).toHaveBeenCalled();
+		});
+
 		it('should start a shift successfully', async () => {
 			const mockShiftId = 'shift-123';
 			const mockOpenShift = {id: mockShiftId, startDate: '2024-01-15T10:00:00.000Z'};
@@ -164,6 +173,14 @@ describe('Shift', () => {
 	});
 
 	describe('finish', () => {
+		it('should throw error when user does not have staff authorization', async () => {
+			getStaffAuthorizationData.mockReturnValueOnce({hasStaffAuthorization: false});
+
+			await expect(Shift.finish()).rejects.toThrow('Staff MS authorization is required');
+			expect(mockCrashlytics.log).toHaveBeenCalled();
+			expect(mockCrashlytics.recordError).toHaveBeenCalled();
+		});
+
 		it('should finish a shift successfully and send pending worklogs', async () => {
 			const mockShiftId = 'shift-999';
 			const expectedUpdatedShiftData = {
@@ -389,6 +406,14 @@ describe('Shift', () => {
 	});
 
 	describe('getUserOpenShift', () => {
+		it('should throw error when user does not have staff authorization', async () => {
+			getStaffAuthorizationData.mockReturnValueOnce({hasStaffAuthorization: false});
+
+			await expect(Shift.getUserOpenShift()).rejects.toThrow('Staff MS authorization is required');
+			expect(mockCrashlytics.log).toHaveBeenCalled();
+			expect(mockCrashlytics.recordError).toHaveBeenCalled();
+		});
+
 		it('should get user open shift successfully', async () => {
 			const mockShift = {id: 'shift-123', status: 'opened'};
 			StaffService.getShiftsList.mockResolvedValueOnce({
@@ -426,6 +451,14 @@ describe('Shift', () => {
 	});
 
 	describe('fetchWorklogTypes', () => {
+		it('should throw error when user does not have staff authorization', async () => {
+			getStaffAuthorizationData.mockReturnValueOnce({hasStaffAuthorization: false});
+
+			await expect(Shift.fetchWorklogTypes()).rejects.toThrow('Staff MS authorization is required');
+			expect(mockCrashlytics.log).toHaveBeenCalled();
+			expect(mockCrashlytics.recordError).toHaveBeenCalled();
+		});
+
 		it('should fetch worklog types successfully', async () => {
 			StaffService.getWorkLogTypes.mockResolvedValueOnce({
 				result: worklogTypes,
@@ -514,6 +547,16 @@ describe('Shift', () => {
 	});
 
 	describe('openWorkLog', () => {
+		it('should throw error when user does not have staff authorization', async () => {
+			getStaffAuthorizationData.mockReturnValueOnce({hasStaffAuthorization: false});
+
+			await expect(Shift.openWorkLog({referenceId: 'test'})).rejects.toThrow(
+				'Staff MS authorization is required'
+			);
+			expect(mockCrashlytics.log).toHaveBeenCalled();
+			expect(mockCrashlytics.recordError).toHaveBeenCalled();
+		});
+
 		it('should open worklog successfully and pause shift for normal activities', async () => {
 			const mockShiftId = 'shift-123';
 			const mockFormattedId = 'ref-123-mock-random-id';
@@ -774,6 +817,16 @@ describe('Shift', () => {
 	});
 
 	describe('finishWorkLog', () => {
+		it('should throw error when user does not have staff authorization', async () => {
+			getStaffAuthorizationData.mockReturnValueOnce({hasStaffAuthorization: false});
+
+			await expect(Shift.finishWorkLog({referenceId: 'test'})).rejects.toThrow(
+				'Staff MS authorization is required'
+			);
+			expect(mockCrashlytics.log).toHaveBeenCalled();
+			expect(mockCrashlytics.recordError).toHaveBeenCalled();
+		});
+
 		it('should finish worklog successfully', async () => {
 			const mockShiftId = 'shift-123';
 			const mockShiftStatus = 'opened';
@@ -1278,6 +1331,16 @@ describe('Shift', () => {
 	});
 
 	describe('getWorkLogs', () => {
+		it('should throw error when user does not have staff authorization', async () => {
+			getStaffAuthorizationData.mockReturnValueOnce({hasStaffAuthorization: false});
+
+			await expect(Shift.getWorkLogs('shift-123')).rejects.toThrow(
+				'Staff MS authorization is required'
+			);
+			expect(mockCrashlytics.log).toHaveBeenCalled();
+			expect(mockCrashlytics.recordError).toHaveBeenCalled();
+		});
+
 		it('should get work logs successfully when shiftId is provided as argument', async () => {
 			const mockShiftId = 'shift-123';
 			ShiftWorklogs.getList.mockResolvedValueOnce(mockWorkLogsRaw);
@@ -1369,6 +1432,16 @@ describe('Shift', () => {
 	});
 
 	describe('sendPendingWorkLogs', () => {
+		it('should throw error when user does not have staff authorization', async () => {
+			getStaffAuthorizationData.mockReturnValueOnce({hasStaffAuthorization: false});
+
+			await expect(Shift.sendPendingWorkLogs()).rejects.toThrow(
+				'Staff MS authorization is required'
+			);
+			expect(mockCrashlytics.log).toHaveBeenCalled();
+			expect(mockCrashlytics.recordError).toHaveBeenCalled();
+		});
+
 		it('should send pending worklogs successfully', async () => {
 			jest.spyOn(Shift, 'isDateToCloseExceeded').mockReturnValueOnce(false);
 
@@ -1433,6 +1506,14 @@ describe('Shift', () => {
 	});
 
 	describe('reOpen', () => {
+		it('should throw error when user does not have staff authorization', async () => {
+			getStaffAuthorizationData.mockReturnValueOnce({hasStaffAuthorization: false});
+
+			await expect(Shift.reOpen()).rejects.toThrow('Staff MS authorization is required');
+			expect(mockCrashlytics.log).toHaveBeenCalled();
+			expect(mockCrashlytics.recordError).toHaveBeenCalled();
+		});
+
 		const storageData = {
 			dateMaxToClose: '2024-01-15T20:00:00.000Z', // Fecha futura (9.5 horas después del mockDate)
 		};

--- a/lib/Shift.js
+++ b/lib/Shift.js
@@ -4,7 +4,7 @@ import Storage from './db/StorageService';
 import Crashlytics from './utils/crashlytics';
 import ShiftWorklogs from './ShiftWorklogs';
 import {generateRandomId, isEmptyArray, isEmptyObject, isObject} from './utils/helpers';
-import {getObject, getShiftData, setObject} from './utils/storage';
+import {getObject, getShiftData, getStaffAuthorizationData, setObject} from './utils/storage';
 import {
 	SHIFT_ID,
 	SHIFT_STATUS,
@@ -24,10 +24,25 @@ import OfflineData from './OfflineData';
 
 class Shift {
 	/**
-	 * Open a work shift in the staff MS and record this event in the time tracking database.
-	 * @param {Object} params
-	 * @throws {Error} error
-	 * @returns {Promise<string>} shiftId => ID related to the shift that has just been opened for the user
+	 * @returns {boolean} hasStaffAuthorization => true if the user has staff MS authorization, false otherwise
+	 */
+
+	get hasStaffAuthorize() {
+		const {hasStaffAuthorization} = getStaffAuthorizationData();
+		return hasStaffAuthorization;
+	}
+
+	/**
+	 * @returns {boolean} hasPendingData => true if the user has pending data, false otherwise
+	 */
+
+	get hasPendingData() {
+		return OfflineData.hasData;
+	}
+
+	/**
+	 * Check if the staff MS is enabled
+	 * @returns {Promise<boolean>} true if the staff MS is enabled, false otherwise
 	 */
 
 	async checkStaffMSAuthorization() {
@@ -43,9 +58,19 @@ class Shift {
 		}
 	}
 
+	/**
+	 * Open a work shift in the staff MS and record this event in the time tracking database.
+	 * @param {Object} params
+	 * @throws {Error} error
+	 * @returns {Promise<string>} shiftId => ID related to the shift that has just been opened for the user
+	 */
+
 	async open(params = {}) {
 		try {
 			Crashlytics.log('user open shift');
+
+			this._requireStaffAuthorization();
+
 			const {date} = params;
 			const {result: shift} = await StaffService.openShift();
 			const {id: shiftId = ''} = shift || {};
@@ -78,13 +103,16 @@ class Shift {
 	async finish(params = {}) {
 		try {
 			Crashlytics.log('user close shift');
+
+			this._requireStaffAuthorization();
+
 			const shiftIsExpired = this.isDateToCloseExceeded();
 
 			if (shiftIsExpired) {
 				await this.reOpen();
 			}
 
-			if (OfflineData.hasData) {
+			if (this.hasPendingData) {
 				await this.sendPendingWorkLogs();
 			}
 
@@ -125,6 +153,8 @@ class Shift {
 	async openWorkLog(workLog = {}) {
 		try {
 			Crashlytics.log('user open shift worklog', workLog);
+
+			this._requireStaffAuthorization();
 
 			if (!isObject(workLog) || isEmptyObject(workLog)) return null;
 
@@ -195,6 +225,9 @@ class Shift {
 	async finishWorkLog(workLog = {}) {
 		try {
 			Crashlytics.log('user close shift worklog', workLog);
+
+			this._requireStaffAuthorization();
+
 			if (!isObject(workLog) || isEmptyObject(workLog)) return null;
 
 			const {referenceId, name, type} = workLog;
@@ -242,6 +275,10 @@ class Shift {
 
 	async sendPendingWorkLogs() {
 		try {
+			Crashlytics.log('user send pending work logs');
+
+			this._requireStaffAuthorization();
+
 			const storageData = OfflineData.get();
 			const formatedWorkLogs = Formatter.formatOfflineWorkLog(storageData);
 
@@ -274,6 +311,9 @@ class Shift {
 	async getUserOpenShift(params = {}) {
 		try {
 			Crashlytics.log('user get open shift', params);
+
+			this._requireStaffAuthorization();
+
 			const {userId, id, ...rest} = params;
 			const {result: shifts} = await StaffService.getShiftsList({
 				filters: {
@@ -302,6 +342,9 @@ class Shift {
 	async getWorkLogs(shiftId) {
 		try {
 			Crashlytics.log('user get work logs');
+
+			this._requireStaffAuthorization();
+
 			const userShiftId = shiftId || Storage.getString(SHIFT_ID);
 
 			if (!userShiftId) throw new Error('Shift ID not found');
@@ -324,6 +367,9 @@ class Shift {
 	async reOpen() {
 		try {
 			Crashlytics.log('user re open shift');
+
+			this._requireStaffAuthorization();
+
 			const shiftIsExpired = this.isDateMaxToCloseExceeded();
 
 			if (shiftIsExpired) {
@@ -441,6 +487,9 @@ class Shift {
 	async fetchWorklogTypes() {
 		try {
 			Crashlytics.log('user fetch worklog types');
+
+			this._requireStaffAuthorization();
+
 			const {result: workLogTypes = []} = await StaffService.getWorkLogTypes();
 
 			return Formatter.formatWorkLogTypes(workLogTypes);
@@ -533,6 +582,18 @@ class Shift {
 		shiftData.dateToClose = new Date(updatedClosingDate).toISOString();
 
 		setObject(SHIFT_DATA, shiftData);
+	}
+
+	/**
+	 * @private
+	 * Validate if the user has staff MS authorization
+	 * @throws {Error} error
+	 * @returns {Promise<null>} null
+	 */
+
+	_requireStaffAuthorization() {
+		if (this.hasStaffAuthorize) return;
+		throw new Error('Staff MS authorization is required');
 	}
 }
 export default new Shift();

--- a/setupTest/jest.setup.js
+++ b/setupTest/jest.setup.js
@@ -195,7 +195,7 @@ jest.mock('../lib/utils/storage', () => ({
 	__esModule: true,
 	getShiftData: jest.fn(),
 	getWorkLogTypesData: jest.fn(),
-	getStaffAuthorizationData: jest.fn(),
+	getStaffAuthorizationData: jest.fn(() => ({hasStaffAuthorization: true})),
 	setObject: jest.fn(),
 	getObject: jest.fn(),
 }));


### PR DESCRIPTION
## LINK DE TICKET
https://janiscommerce.atlassian.net/browse/APPSRN-409
## DESCRIPCIÓN DEL REQUERIMIENTO
Se requiere que el pkg agregue una validación antes de ejecutar cada metodo de shift. Esto se hará para evitar que aquellos usuarios que no tengan permisos para usar el sistema de shift-tracking reciban un mensaje de error que notifique el problema en cuestión.
También será necesario contar con un método que nos permita saber si el usuario tiene información pendiente de ser enviada a janis o no.
## DESCRIPCIÓN DE LA SOLUCIÓN
Se agregaron 2 getters a la clase shift, que son:
-  `hasStaffAuthorize`, que valida si el usuario tiene permisos contra la info que se encuentra guardada en el storage.
-  `hasPendingData`, que valida si el usuario tiene worklogs almacenados en la DB que se encuentren pendientes de reportar a janis.

 `hasStaffAuthorize` fue agregado en varios métodos (no todos) de la clase shift para evitar que el usuario interactúe con janis si no tiene permisos para usar el MS de staff.
Esta validación prohibe al usuario sin permisos lo siguiente:
- abrir y cerrar turnos
- abrir y cerrar actividades
- obtener información relacionada a turnos, tipo de actividades y actividades desde janis.

Sin embargo, esto no limita el funcionamiento de métodos como:
- `getReport`
- `deleteShiftRegisters`
- `isDateToCloseExceeded`
etc.

evite hacer esta distinción para que la app no sufra comportamientos inesperados, cómo por ejemplo:
- El usuario (sin permisos) quiere cerrar su sesión desde el menú de usuario, que a su vez borra la info de todo shift-tracking. Si agregara la validación de permisos en `deleteShiftRegisters`, el usuario recibiría el error de no tener permisos para shift, cuando lo que quiere hacer es cerrar su sesión.

## CÓMO PROBARLO
Vincular el pkg a la app y modificar `hasStaffAuthorize` para que devuelva false. 
Pruebe iniciar una actividad; debería recibir el mensaje de error de falta de permisos.
Luego restaure `hasStaffAuthorize` a su versión original e inicie una actividad; chequee (mediante `hasPendingData`) si la clase le devuelve un `true` para indicar que tiene data pendiente
## DATOS EXTRA A TENER EN CUENTA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added staff authorization checks across shift and work log actions (open/finish shifts, view open shift, fetch work log types, open/finish work logs, send pending work logs, re‑open shift). Users without authorization will see a clear error message.
- Chores
  - Improved error monitoring for unauthorized attempts.
- Tests
  - Added comprehensive tests to validate authorization-required behavior and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->